### PR TITLE
Initial Read The Docs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Status
 
-![Master CI Deploy](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_build.yml/badge.svg) ![Master CI Warnings](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_warnings.yml/badge.svg) ![Master CI Linkcheck](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_linkcheck.yml/badge.svg)
+[![Master CI Deploy](https://readthedocs.org/projects/overte-docs/badge/?version=latest)](http://docs.overte.org/en/latest/?badge=latest) ![Master CI Warnings](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_warnings.yml/badge.svg) ![Master CI Linkcheck](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_linkcheck.yml/badge.svg)
 
 # Overview of Vircadia's User Documentation Tools
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,6 +13,11 @@ help:
 
 .PHONY: help Makefile
 
+# Catch HTML to create a symlink from index.html to home.html
+html:
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	ln -s "home.html" "$(BUILDDIR)/html/index.html"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+myst-parser>=0.14.0
+Sphinx>=3.5.4
+sphinx-intl>=2.0.1
+sphinx-rtd-theme>=0.5.2
+git+https://github.com/vircadia/video.git


### PR DESCRIPTION
This PR adds support for Read The Docs.
We should get automatic deployment at https://docs.overte.org once this is merged.