### PR TITLE
Change how index.html is created

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,11 +13,6 @@ help:
 
 .PHONY: help Makefile
 
-# Catch HTML to create a symlink from index.html to home.html
-html:
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	ln -s "home.html" "$(BUILDDIR)/html/index.html"
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,1 @@
+home.rst


### PR DESCRIPTION
By creating a symlink before building, we generate an index.html for readthedocs to link to.
I hope this doesn't cause problem with translation, but readthedocs support already told me that we will get better configuration/deployment options in the coming months.

This will generate a warning, since index.rst isn't in any doctree.

Check the CI build here: https://overte-docs--2.org.readthedocs.build/en/2/