### PR TITLE
:memo: Updated docs for the updated avatar exporter

### DIFF
--- a/source/create/avatars/find-avatars.rst
+++ b/source/create/avatars/find-avatars.rst
@@ -38,9 +38,9 @@ Overte supports only one standard type of rigging for avatars. Because many avat
 
 You will need the following to use this tool:
 
-+ Unity (Recommended versions: 2017.4.17f1 - 2018.2.12f1)
++ Unity (Recommended versions: 2019.4.31f1)
 + Overte
-+ `Overte Avatar Exporter for Unity <https://github.com/overte-org/overte/blob/master/tools/unity-avatar-exporter/avatarExporter.unitypackage?raw=true>`_ (v0.4.1)
++ `Overte Avatar Exporter for Unity <https://github.com/overte-org/overte/blob/master/tools/unity-avatar-exporter/avatarExporter.unitypackage?raw=true>`_ (v0.6.0)
 
 Please note that the recommended version of Unity is not the latest version. If you are using a newer version of Unity, we recommend that you apply a T-Pose to your avatar. To do so, go to the 'Inspector', and click 'Pose' near the bottom of the panel. Select 'Enforce T-Pose' from the drop-down. Click 'Apply' and 'Done'. We recommend doing this after correcting any issues with remapping bones.
 
@@ -61,7 +61,7 @@ You need to install the extension for every Unity project that you have. Keep in
 
 4. Navigate to the `avatarExporter` package (with a .unitypackage extension). Click 'Open'. You can also double-click the package on your computer to import it automatically.
 5. In the 'Importing Package' window, review the list of files to be imported and check for conflicts with files already in your project. If a conflict exists, save any local changes somewhere outside of your project.
-6. Click 'Import'. The package's files are added to the Assets folder. You should now have a 'High Fidelity' menu in Unity.
+6. Click 'Import'. The package's files are added to the Assets folder. You should now have a 'Overte' menu in Unity.
 
 .. image:: _images/hifi-menu.png
 
@@ -98,8 +98,8 @@ Create an Avatar Package
 
 .. image:: _images/select-avatar-unity.png
 
-7. Make sure that you have the `avatar exporter installed <#install-the-avatar-exporter>`_. Open the 'High Fidelity' menu in the top menu bar, then select 'Export New Avatar'.
-8. Give your avatar project a name. The default project location is your local user's ``Documents\High Fidelity Projects`` directory, which is created automatically for you. Though we recommend that you keep your avatars in this directory, you can change it to another location on your computer.
+7. Make sure that you have the `avatar exporter installed <#install-the-avatar-exporter>`_. Open the 'Overte' menu in the top menu bar, then select 'Export New Avatar'.
+8. Give your avatar project a name. The default project location is your local user's ``Documents\Overte Projects`` directory, which is created automatically for you. Though we recommend that you keep your avatars in this directory, you can change it to another location on your computer.
 
 .. image:: _images/export-avatar.png
 
@@ -109,7 +109,7 @@ Your avatar package has been created! The File Explorer will open to your new av
 
 .. image:: _images/exported-package.png
 
-.. note:: If you are using any external textures with your avatar model, copy those textures to your local user's ``Documents\High Fidelity Projects\avatar\<project name>\textures`` directory. Otherwise, they may not show up on your avatar.
+.. note:: If you are using any external textures with your avatar model, copy those textures to your local user's ``Documents\Overte Projects\avatar\<project name>\textures`` directory. Otherwise, they may not show up on your avatar.
 
 ^^^^^^^^^^^^^^^^
 Test Your Avatar

--- a/source/create/avatars/package-avatar.rst
+++ b/source/create/avatars/package-avatar.rst
@@ -6,7 +6,7 @@
 Package and Host Your Avatar
 ##################################
 
-At a minimum, avatars in Overte must have an FBX, glTF, or GLB model, and an associated FST file that includes information about how your avatar looks and behaves. Together, these two files (with any optional texture or script) form an "avatar package". There are two ways you can create an avatar package: by using the `Avatar Packager`_ in Interface or the `Overte Avatar Exporter for Unity (unmaintained)`_ in Unity.
+At a minimum, avatars in Overte must have an FBX, glTF, or GLB model, and an associated FST file that includes information about how your avatar looks and behaves. Together, these two files (with any optional texture or script) form an "avatar package". There are two ways you can create an avatar package: by using the `Avatar Packager`_ in Interface or the `Overte Avatar Exporter for Unity`_ in Unity.
 
 Once you have packaged your avatar, you need to host it on the cloud so that Overte can access it and correctly render your avatar for all users.
 
@@ -22,7 +22,7 @@ If you're reading this page, you likely already :doc:`built your own FBX model <
 We provide two ways to create an avatar package: either through Unity or through our Avatar Packager.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Overte Avatar Exporter for Unity (unmaintained)
+Overte Avatar Exporter for Unity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In some cases, you will want to :doc:`download an avatar from an external website <find-avatars>` and use that avatar in Overte. The Overte Avatar Exporter for Unity (also known as the "avatar exporter") converts human-like avatars and packages them for use in Overte. 
@@ -377,7 +377,7 @@ The Avatar Packager will notify you of any errors or warnings that may affect th
                             <p>Ensure that your avatar package has both an FST and FBX file.</p>
                             <ul class="first arabic simple">
                                 <li>If you are missing your FBX file, locate it and copy it back into this folder.</li>
-                                <li>If you are missing an FST file, <a href="#package-your-avatar">re-package your avatar</a> using either the High Fidelity Exporter Avatar Exporter for Unity or the Avatar Packager.</li>
+                                <li>If you are missing an FST file, <a href="#package-your-avatar">re-package your avatar</a> using either the Overte Avatar Exporter for Unity or the Avatar Packager.</li>
                             </ul>
                         </li>
                         <li>If both files are there and you still receive this error, open the FST file in a text editor of your choice. </li>


### PR DESCRIPTION
Part of PR overte-org/overte#552

**Changes**
* Updated recommended unity version to `2019.4.31f1` 
* Replaced `High Fidelity` with `Overte`
* Removed `unmaintained` from the docs