### PR TITLE
Work around ReadTheDocs issues

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   # "os" and "tools" are required to be able to use "jobs"
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     pre_build:
       - echo "Creating an index.html to work around not being able to set the default web page.."

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,12 @@ myst-parser>=0.14.0, <0.17.0
 # myst-parser < 0.17.2 requires attrs but the package doesn't depend on it.
 attrs
 
+# ReadTheDocs indirectly depends on some too new extension versions. Upgrading myst-parser later should fix this.
+sphinxcontrib-applehelp<=1.0.4
+sphinxcontrib-devhelp<=1.0.5
+sphinxcontrib-htmlhelp<=2.0.4
+sphinxcontrib-serializinghtml<=1.1.9
+sphinxcontrib-qthelp<=1.0.6
+
 # Utility for easily running builds in Python virtual environments.
 venv-run

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Overte Docs'
-copyright = '2019, High Fidelity. © Copyright 2021, Vircadia. Copyright 2022-2023, Overte e.V.'
+copyright = '2019, High Fidelity. © Copyright 2021, Vircadia. Copyright 2022-2024, Overte e.V.'
 author = 'Overte e.V.'
 
 # The short X.Y version


### PR DESCRIPTION
This works around issues with ReadTheDocs builds. Without this, *deployment* and PR builds are broken.