### PR TITLE
Clarify when an entity script runs on users' client

### DIFF
--- a/source/script/client-entity-scripts.md
+++ b/source/script/client-entity-scripts.md
@@ -1,6 +1,6 @@
 # Client Entity Scripts
 
-You can make content in Overte interactive by attaching scripts to entities. *Client entity scripts* are entity scripts that run locally on each user's computer. When a user comes into contact with the entity, it will "preload" (or run) the script, then "unload" (or stop) the script when the user leaves.
+You can make content in Overte interactive by attaching scripts to entities. *Client entity scripts* are entity scripts that run locally on each user's computer. When a user encounters the entity by loading it into view, it will "preload" (or run) the script, then "unload" (or stop) the script when the user leaves.
 
 There can be (and typically are) multiple entities in a domain, and each one can have a different client entity script associated with it.
 


### PR DESCRIPTION
* Previously implied user must touch the entity (comes into contact with the entity)
* Now clarifies that they just need to load the entity (encounters the entity by loading it into view)